### PR TITLE
Mobile-200: handle image upload fix

### DIFF
--- a/compnents/cloudflareBucketCalls/cloudflareAWSCalls.js
+++ b/compnents/cloudflareBucketCalls/cloudflareAWSCalls.js
@@ -6,16 +6,21 @@ import {
 import 'react-native-get-random-values'
 import 'react-native-url-polyfill/auto';
 import { ReadableStream } from 'web-streams-polyfill/ponyfill';
+import { Buffer } from 'buffer';
+
 globalThis.ReadableStream = ReadableStream;
 
 export const uploadphoto = async (file, fileName) => {
 
+    const fileBuffer = Buffer.from(file, 'base64');
+    const fileSize = fileBuffer.length;
+
     const input = {
-        "Body": file,
+        "Body": fileBuffer,
         "Bucket": "scubaseasons",
         "Key": fileName,
         "ContentType": "image/jpeg",
-        // "Content-Length": fileSize
+        "Content-Length": fileSize
     }
 
     const command = new PutObjectCommand(input)

--- a/compnents/mapPage.js
+++ b/compnents/mapPage.js
@@ -109,7 +109,7 @@ export default function MapPage() {
   const [isOpen, setIsOpen] = useState(false);
 
   const locales = getLocales();
-  console.log("locales", locales);
+  // console.log("locales", locales);
   
   useEffect(() => {
     filterAnchorPhotos();

--- a/compnents/screens/diveShop.js
+++ b/compnents/screens/diveShop.js
@@ -24,15 +24,11 @@ import { LevelOneScreenContext } from "../contexts/levelOneScreenContext";
 import { MapCenterContext } from "../contexts/mapCenterContext";
 import { ZoomHelperContext } from "../contexts/zoomHelperContext";
 import { MaterialIcons } from "@expo/vector-icons";
-import { chooseImageHandler } from "./imageUploadHelpers";
-import {
-  uploadphoto,
-  removePhoto,
-} from "./../cloudflareBucketCalls/cloudflareAWSCalls";
+import { chooseImageHandler, imageUpload } from "./imageUploadHelpers";
+import { removePhoto } from "./../cloudflareBucketCalls/cloudflareAWSCalls";
 import { itineraries } from "../../supabaseCalls/itinerarySupabaseCalls";
 import { updateDiveShop } from "../../supabaseCalls/shopsSupabaseCalls";
 import BottomDrawer from "./animatedBottomDrawer";
-import * as FileSystem from 'expo-file-system';
 
 const windowHeight = Dimensions.get("window").height;
 
@@ -118,22 +114,7 @@ export default function DiveShop() {
       const image = await chooseImageHandler();
       if (image) {
 
-        let uri = image.assets[0].uri;
-        let extension = image.assets[0].uri.split(".").pop();
-        const fileName = Date.now() + "." + extension;
-
-        const newFileUri = FileSystem.documentDirectory + fileName;
-
-        await FileSystem.moveAsync({
-          from: uri,
-          to: newFileUri,
-        });
-
-        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
-
-        await uploadphoto(fileInfo, fileName);
+        let fileName = await imageUpload(image)
 
         if (diveShopVals.photo !== null || diveShopVals.photo === "") {
           await removePhoto({

--- a/compnents/screens/diveShop.js
+++ b/compnents/screens/diveShop.js
@@ -32,6 +32,7 @@ import {
 import { itineraries } from "../../supabaseCalls/itinerarySupabaseCalls";
 import { updateDiveShop } from "../../supabaseCalls/shopsSupabaseCalls";
 import BottomDrawer from "./animatedBottomDrawer";
+import * as FileSystem from 'expo-file-system';
 
 const windowHeight = Dimensions.get("window").height;
 
@@ -116,14 +117,24 @@ export default function DiveShop() {
     try {
       const image = await chooseImageHandler();
       if (image) {
+
         let uri = image.assets[0].uri;
         let extension = image.assets[0].uri.split(".").pop();
         const fileName = Date.now() + "." + extension;
 
-        //create new photo file and upload
-        let picture = await fetch(uri);
-        picture = await picture.blob();
-        await uploadphoto(picture, fileName);
+        const newFileUri = FileSystem.documentDirectory + fileName;
+
+        await FileSystem.moveAsync({
+          from: uri,
+          to: newFileUri,
+        });
+
+        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
+          encoding: FileSystem.EncodingType.Base64,
+        });
+
+        await uploadphoto(fileInfo, fileName);
+
         if (diveShopVals.photo !== null || diveShopVals.photo === "") {
           await removePhoto({
             filePath: `https://pub-c089cae46f7047e498ea7f80125058d5.r2.dev/`,

--- a/compnents/screens/diveSite.js
+++ b/compnents/screens/diveSite.js
@@ -33,12 +33,9 @@ import { LevelTwoScreenContext } from "../contexts/levelTwoScreenContext";
 import { MaterialIcons } from "@expo/vector-icons";
 import email from "react-native-email";
 import { newGPSBoundaries } from "../helpers/mapHelpers";
-import { chooseImageHandler } from "./imageUploadHelpers";
+import { chooseImageHandler, imageUpload } from "./imageUploadHelpers";
 import { useButtonPressHelper } from "../FABMenu/buttonPressHelper";
-import {
-  uploadphoto,
-  removePhoto,
-} from "./../cloudflareBucketCalls/cloudflareAWSCalls";
+import { removePhoto } from "./../cloudflareBucketCalls/cloudflareAWSCalls";
 import {
   getPhotosWithUser,
   getPhotosWithUserEmpty,
@@ -50,7 +47,6 @@ import {
 } from "../../supabaseCalls/diveSiteSupabaseCalls";
 import { getItinerariesForDiveSite } from "../../supabaseCalls/itinerarySupabaseCalls";
 import BottomDrawer from "./animatedBottomDrawer";
-import * as FileSystem from 'expo-file-system';
 
 const windowHeight = Dimensions.get("window").height;
 
@@ -188,22 +184,7 @@ export default function DiveSite() {
       const image = await chooseImageHandler();
       if (image) {
         
-        let uri = image.assets[0].uri;
-        let extension = image.assets[0].uri.split(".").pop();
-        const fileName = Date.now() + "." + extension;
-
-        const newFileUri = FileSystem.documentDirectory + fileName;
-
-        await FileSystem.moveAsync({
-          from: uri,
-          to: newFileUri,
-        });
-
-        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
-
-        await uploadphoto(fileInfo, fileName);
+        let fileName = await imageUpload(image)
 
         if (
           site.divesiteprofilephoto !== null ||

--- a/compnents/screens/diveSite.js
+++ b/compnents/screens/diveSite.js
@@ -50,6 +50,7 @@ import {
 } from "../../supabaseCalls/diveSiteSupabaseCalls";
 import { getItinerariesForDiveSite } from "../../supabaseCalls/itinerarySupabaseCalls";
 import BottomDrawer from "./animatedBottomDrawer";
+import * as FileSystem from 'expo-file-system';
 
 const windowHeight = Dimensions.get("window").height;
 
@@ -203,7 +204,7 @@ export default function DiveSite() {
         });
 
         await uploadphoto(fileInfo, fileName);
-        
+
         if (
           site.divesiteprofilephoto !== null ||
           site.divesiteprofilephoto === ""

--- a/compnents/screens/diveSite.js
+++ b/compnents/screens/diveSite.js
@@ -186,14 +186,24 @@ export default function DiveSite() {
     try {
       const image = await chooseImageHandler();
       if (image) {
+        
         let uri = image.assets[0].uri;
         let extension = image.assets[0].uri.split(".").pop();
         const fileName = Date.now() + "." + extension;
 
-        //create new photo file and upload
-        let picture = await fetch(uri);
-        picture = await picture.blob();
-        await uploadphoto(picture, fileName);
+        const newFileUri = FileSystem.documentDirectory + fileName;
+
+        await FileSystem.moveAsync({
+          from: uri,
+          to: newFileUri,
+        });
+
+        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
+          encoding: FileSystem.EncodingType.Base64,
+        });
+
+        await uploadphoto(fileInfo, fileName);
+        
         if (
           site.divesiteprofilephoto !== null ||
           site.divesiteprofilephoto === ""

--- a/compnents/screens/imageUploadHelpers.js
+++ b/compnents/screens/imageUploadHelpers.js
@@ -1,5 +1,7 @@
 import * as ImagePicker from "expo-image-picker";
+import * as FileSystem from 'expo-file-system';
 import { registerForPhotoLibraryAccessAsync } from "../tutorial/photoLibraryRegistery";
+import { uploadphoto } from "./../cloudflareBucketCalls/cloudflareAWSCalls";
 
 export const chooseImageHandler = async() => {
 let permissionGiven = await registerForPhotoLibraryAccessAsync("yes");
@@ -22,6 +24,34 @@ try {
   console.log({ title: "Image Upload", message: e.message });
 }
 }
+
+
+export const imageUpload = async (image) => {
+
+  let uri = image.assets[0].uri;
+  let extension = image.assets[0].uri.split(".").pop();
+  const fileName = Date.now() + "." + extension;
+
+  const newFileUri = FileSystem.documentDirectory + fileName;
+
+  await FileSystem.moveAsync({
+    from: uri,
+    to: newFileUri,
+  });
+
+  const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+
+  await uploadphoto(fileInfo, fileName);
+
+  return(fileName);
+
+}
+
+
+
+
 
 function formatDate(dateTaken) {
 

--- a/compnents/screens/imageUploadHelpers.js
+++ b/compnents/screens/imageUploadHelpers.js
@@ -1,5 +1,6 @@
 
 import * as ImagePicker from "expo-image-picker";
+import * as FileSystem from 'expo-file-system';
 import { registerForPhotoLibraryAccessAsync } from "../tutorial/photoLibraryRegistery";
 
 export const chooseImageHandler = async() => {
@@ -10,7 +11,7 @@ if (!permissionGiven) {
 }
 
 let chosenImage = await ImagePicker.launchImageLibraryAsync({
-  mediaTypes: ImagePicker.MediaTypeOptions.Images,
+  mediaTypes: ['images', 'videos'],
   allowsEditing: true,
   aspect: [4, 3],
   quality: 1,
@@ -23,7 +24,6 @@ try {
   console.log({ title: "Image Upload", message: e.message });
 }
 }
-
 
 function formatDate(dateTaken) {
 

--- a/compnents/screens/imageUploadHelpers.js
+++ b/compnents/screens/imageUploadHelpers.js
@@ -1,6 +1,4 @@
-
 import * as ImagePicker from "expo-image-picker";
-import * as FileSystem from 'expo-file-system';
 import { registerForPhotoLibraryAccessAsync } from "../tutorial/photoLibraryRegistery";
 
 export const chooseImageHandler = async() => {

--- a/compnents/screens/picUploader.js
+++ b/compnents/screens/picUploader.js
@@ -35,6 +35,7 @@ import { chooseImageHandler } from "./imageUploadHelpers";
 import { ActiveConfirmationIDContext } from "../contexts/activeConfirmationIDContext";
 import { ConfirmationTypeContext } from "../contexts/confirmationTypeContext";
 import { ConfirmationModalContext } from "../contexts/confirmationModalContext";
+import * as FileSystem from 'expo-file-system';
 
 const windowWidth = Dimensions.get("window").width;
 const windowHeight = Dimensions.get("window").height;
@@ -72,14 +73,24 @@ export default function PicUploader() {
     try {
       const image = await chooseImageHandler();
       if (image) {
+        
         let uri = image.assets[0].uri;
         let extension = image.assets[0].uri.split(".").pop();
         const fileName = Date.now() + "." + extension;
 
-        //create new photo file and upload
-        let picture = await fetch(uri);
-        picture = await picture.blob();
-        await uploadphoto(picture, fileName);
+        const newFileUri = FileSystem.documentDirectory + fileName;
+
+        await FileSystem.moveAsync({
+          from: uri,
+          to: newFileUri,
+        });
+
+        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
+          encoding: FileSystem.EncodingType.Base64,
+        });
+
+        await uploadphoto(fileInfo, fileName);
+
         if (pinValues.PicFile !== null || pinValues.PicFile === "") {
           await removePhoto({
             filePath: `https://pub-c089cae46f7047e498ea7f80125058d5.r2.dev/`,

--- a/compnents/screens/picUploader.js
+++ b/compnents/screens/picUploader.js
@@ -27,15 +27,11 @@ import { LevelTwoScreenContext } from "../contexts/levelTwoScreenContext";
 import { PinContext } from "../contexts/staticPinContext";
 import { MaterialIcons } from "@expo/vector-icons";
 import { insertPhotoWaits } from "../../supabaseCalls/photoWaitSupabaseCalls";
-import {
-  uploadphoto,
-  removePhoto,
-} from "../cloudflareBucketCalls/cloudflareAWSCalls";
-import { chooseImageHandler } from "./imageUploadHelpers";
+import { removePhoto } from "../cloudflareBucketCalls/cloudflareAWSCalls";
+import { chooseImageHandler, imageUpload } from "./imageUploadHelpers";
 import { ActiveConfirmationIDContext } from "../contexts/activeConfirmationIDContext";
 import { ConfirmationTypeContext } from "../contexts/confirmationTypeContext";
 import { ConfirmationModalContext } from "../contexts/confirmationModalContext";
-import * as FileSystem from 'expo-file-system';
 
 const windowWidth = Dimensions.get("window").width;
 const windowHeight = Dimensions.get("window").height;
@@ -74,22 +70,7 @@ export default function PicUploader() {
       const image = await chooseImageHandler();
       if (image) {
         
-        let uri = image.assets[0].uri;
-        let extension = image.assets[0].uri.split(".").pop();
-        const fileName = Date.now() + "." + extension;
-
-        const newFileUri = FileSystem.documentDirectory + fileName;
-
-        await FileSystem.moveAsync({
-          from: uri,
-          to: newFileUri,
-        });
-
-        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
-
-        await uploadphoto(fileInfo, fileName);
+        let fileName = await imageUpload(image)
 
         if (pinValues.PicFile !== null || pinValues.PicFile === "") {
           await removePhoto({

--- a/compnents/screens/userProfile.js
+++ b/compnents/screens/userProfile.js
@@ -37,17 +37,13 @@ import { registerForPushNotificationsAsync } from "../tutorial/notificationsRegi
 import { useButtonPressHelper } from "../FABMenu/buttonPressHelper";
 import { chooseImageHandler, imageUpload} from "./imageUploadHelpers";
 import BottomDrawer from "./animatedBottomDrawer";
-import {
-  uploadphoto,
-  removePhoto,
-} from "./../cloudflareBucketCalls/cloudflareAWSCalls";
+import { removePhoto } from "./../cloudflareBucketCalls/cloudflareAWSCalls";
 import {
   insertUserFollow,
   deleteUserFollow,
   checkIfUserFollows,
 } from "../../supabaseCalls/userFollowSupabaseCalls";
 import { getProfileWithStats } from "../../supabaseCalls/accountSupabaseCalls";
-import * as FileSystem from 'expo-file-system';
 
 const windowHeight = Dimensions.get("window").height;
 

--- a/compnents/screens/userProfile.js
+++ b/compnents/screens/userProfile.js
@@ -186,7 +186,7 @@ if (selectedProfile){followCheck()}
           bio: profileVals.bio,
           photo: profileVals.profilePhoto,
         });
-        if (success[0].length === 0 && profileVals) {
+        if (success.length === 0 && profileVals) {
           setProfileVals({ ...profileVals, userName: tempUserName });
           setUserFail("Sorry that diver name has already been taken");
         }

--- a/compnents/screens/userProfile.js
+++ b/compnents/screens/userProfile.js
@@ -47,6 +47,7 @@ import {
   checkIfUserFollows,
 } from "../../supabaseCalls/userFollowSupabaseCalls";
 import { getProfileWithStats } from "../../supabaseCalls/accountSupabaseCalls";
+import * as FileSystem from 'expo-file-system';
 
 const windowHeight = Dimensions.get("window").height;
 
@@ -201,14 +202,24 @@ if (selectedProfile){followCheck()}
     try {
       const image = await chooseImageHandler();
       if (image) {
+        
         let uri = image.assets[0].uri;
         let extension = image.assets[0].uri.split(".").pop();
         const fileName = Date.now() + "." + extension;
 
-        //create new photo file and upload
-        let picture = await fetch(uri);
-        picture = await picture.blob();
-        await uploadphoto(picture, fileName);
+        const newFileUri = FileSystem.documentDirectory + fileName;
+
+        await FileSystem.moveAsync({
+          from: uri,
+          to: newFileUri,
+        });
+
+        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
+          encoding: FileSystem.EncodingType.Base64,
+        });
+
+        await uploadphoto(fileInfo, fileName);
+
         if (profileVals.photo !== null || profileVals.photo === "") {
           await removePhoto({
             filePath: `https://pub-c089cae46f7047e498ea7f80125058d5.r2.dev/`,

--- a/compnents/screens/userProfile.js
+++ b/compnents/screens/userProfile.js
@@ -35,7 +35,7 @@ import { updateProfile } from "../../supabaseCalls/accountSupabaseCalls";
 import { MaterialIcons } from "@expo/vector-icons";
 import { registerForPushNotificationsAsync } from "../tutorial/notificationsRegistery";
 import { useButtonPressHelper } from "../FABMenu/buttonPressHelper";
-import { chooseImageHandler } from "./imageUploadHelpers";
+import { chooseImageHandler, imageUpload} from "./imageUploadHelpers";
 import BottomDrawer from "./animatedBottomDrawer";
 import {
   uploadphoto,
@@ -203,22 +203,7 @@ if (selectedProfile){followCheck()}
       const image = await chooseImageHandler();
       if (image) {
         
-        let uri = image.assets[0].uri;
-        let extension = image.assets[0].uri.split(".").pop();
-        const fileName = Date.now() + "." + extension;
-
-        const newFileUri = FileSystem.documentDirectory + fileName;
-
-        await FileSystem.moveAsync({
-          from: uri,
-          to: newFileUri,
-        });
-
-        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
-
-        await uploadphoto(fileInfo, fileName);
+        let fileName = await imageUpload(image)
 
         if (profileVals.photo !== null || profileVals.photo === "") {
           await removePhoto({

--- a/compnents/screens/wavyHeaderUploader.js
+++ b/compnents/screens/wavyHeaderUploader.js
@@ -6,17 +6,13 @@ import {
   Dimensions,
   ImageBackground,
 } from "react-native";
-import {
-  uploadphoto,
-  removePhoto,
-} from "./../cloudflareBucketCalls/cloudflareAWSCalls";
+import { removePhoto } from "./../cloudflareBucketCalls/cloudflareAWSCalls";
 import screenData from "./screenData.json";
-import { chooseImageHandler } from "./imageUploadHelpers";
+import { chooseImageHandler, imageUpload } from "./imageUploadHelpers";
 import { moderateScale } from "react-native-size-matters";
 import Svg, { Path } from "react-native-svg";
 import { colors, primaryButtonAlt, buttonTextAlt } from "../styles";
 import { TouchableWithoutFeedback } from "react-native-gesture-handler";
-import * as FileSystem from 'expo-file-system';
 
 const windowWidth = Dimensions.get("window").width;
 const windowHeight = Dimensions.get("window").height;
@@ -42,22 +38,8 @@ export default function WavyHeaderUploader({
       const image = await chooseImageHandler();
       if (image) {
 
-        let uri = image.assets[0].uri;
-        let extension = image.assets[0].uri.split(".").pop();
-        const fileName = Date.now() + "." + extension;
+       let fileName = await imageUpload(image)
 
-        const newFileUri = FileSystem.documentDirectory + fileName;
-
-        await FileSystem.moveAsync({
-          from: uri,
-          to: newFileUri,
-        });
-
-        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
-          encoding: FileSystem.EncodingType.Base64,
-        });
-
-        await uploadphoto(fileInfo, fileName);
         if (pinValues.PicFile !== null || pinValues.PicFile === "") {
           await removePhoto({
             filePath: `https://pub-c089cae46f7047e498ea7f80125058d5.r2.dev/`,

--- a/compnents/screens/wavyHeaderUploader.js
+++ b/compnents/screens/wavyHeaderUploader.js
@@ -16,6 +16,8 @@ import { moderateScale } from "react-native-size-matters";
 import Svg, { Path } from "react-native-svg";
 import { colors, primaryButtonAlt, buttonTextAlt } from "../styles";
 import { TouchableWithoutFeedback } from "react-native-gesture-handler";
+import * as FileSystem from 'expo-file-system';
+
 const windowWidth = Dimensions.get("window").width;
 const windowHeight = Dimensions.get("window").height;
 
@@ -39,14 +41,23 @@ export default function WavyHeaderUploader({
     try {
       const image = await chooseImageHandler();
       if (image) {
+
         let uri = image.assets[0].uri;
         let extension = image.assets[0].uri.split(".").pop();
         const fileName = Date.now() + "." + extension;
 
-        //create new photo file and upload
-        let picture = await fetch(uri);
-        picture = await picture.blob();
-        await uploadphoto(picture, fileName);
+        const newFileUri = FileSystem.documentDirectory + fileName;
+
+        await FileSystem.moveAsync({
+          from: uri,
+          to: newFileUri,
+        });
+
+        const fileInfo = await FileSystem.readAsStringAsync(newFileUri, {
+          encoding: FileSystem.EncodingType.Base64,
+        });
+
+        await uploadphoto(fileInfo, fileName);
         if (pinValues.PicFile !== null || pinValues.PicFile === "") {
           await removePhoto({
             filePath: `https://pub-c089cae46f7047e498ea7f80125058d5.r2.dev/`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "react-native-buffer": "^6.0.3",
         "react-native-dotenv": "^3.4.9",
         "react-native-email": "^2.1.0",
+        "react-native-fs": "^2.20.0",
         "react-native-geocoding": "^0.5.0",
         "react-native-gesture-handler": "~2.20.2",
         "react-native-get-random-values": "~1.11.0",
@@ -16485,6 +16486,30 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-fs": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/react-native-fs/-/react-native-fs-2.20.0.tgz",
+      "integrity": "sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "utf8": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-fs/node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
     "node_modules/react-native-geocoding": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/react-native-geocoding/-/react-native-geocoding-0.5.0.tgz",
@@ -19078,6 +19103,12 @@
         "react": ">=16",
         "supercluster": ">=6"
       }
+    },
+    "node_modules/utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+      "license": "MIT"
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-native-buffer": "^6.0.3",
     "react-native-dotenv": "^3.4.9",
     "react-native-email": "^2.1.0",
+    "react-native-fs": "^2.20.0",
     "react-native-geocoding": "^0.5.0",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-get-random-values": "~1.11.0",

--- a/supabaseCalls/accountSupabaseCalls.js
+++ b/supabaseCalls/accountSupabaseCalls.js
@@ -43,19 +43,17 @@ if (data) {
 };
 
 export const updateProfile = async (values) => {
-  const { data, error } = await supabase
+  const response = await supabase
     .from("UserProfiles")
     .update({ UserName: values.username, profileBio: values.bio, profilePhoto: values.photo  })
     .eq("UserID", values.id);
 
-  if (error) {
+  if (response.error) {
     console.log("couldn't do it 2,", error);
     return [];
   }
 
-  if (data) {
-    return data;
-  }
+    return response;
 };
 
 export const updatePushToken = async (values) => {


### PR DESCRIPTION
The Expo 52 update broke the image upload feature
 
Issue was tracked to the way the file was being recreated with the new file name

this PR removed that and uses Expo file System to rename the file without having to recreate the blob file.