### PR TITLE
fixed

### DIFF
--- a/compnents/feed/store/utils.ts
+++ b/compnents/feed/store/utils.ts
@@ -32,10 +32,14 @@ export async function checkFileExists(
 
 export async function checkNetworkStatus() {
   const state = await NetInfo.fetch();
+  const isConnected = !!state.isConnected;
+
+  const internetReachable =
+    state.isInternetReachable === false ? false : true;
+
   return {
-    isConnected: state.isConnected ?? false,
-    isInternetReachable: state.isInternetReachable ?? false,
-    isStableConnection:
-      (state.isConnected && state.isInternetReachable) ?? false,
+    isConnected,
+    isInternetReachable: state.isInternetReachable ?? null,
+    isStableConnection: isConnected && internetReachable,
   };
 }


### PR DESCRIPTION
The issue occurs because the network check (NetInfo) sometimes returns null for isInternetReachable on the first call, meaning it hasn’t determined internet reachability yet. Our current logic treats null as false, which incorrectly flags the network as unstable even if the connection is good.

On the retry, NetInfo has had time to complete the check and returns the correct value (true), so the upload succeeds.